### PR TITLE
Update GRR_PREFIX path

### DIFF
--- a/installfrompip.adoc
+++ b/installfrompip.adoc
@@ -97,7 +97,7 @@ pip install --editable grr/config/grr-response-server
 pip install --no-cache-dir -f https://storage.googleapis.com/releases.grr-response.com/index.html grr-response-templates
 pip install --editable grr/config/grr-response-test
 ----
-Then edit /etc/default/grr-server and set:
+Then edit /grr/debian/grr-server.default and set:
 
 ----
 GRR_PREFIX=/path/to/GRR_NEW


### PR DESCRIPTION
When GRR is installed with pip in virtual environment, the path to default grr-server is present in /grr/debian/grr-server.default. I could not find the file /etc/default/grr-server.
![image](https://cloud.githubusercontent.com/assets/2549509/20070734/8b9bec9c-a4ef-11e6-92a2-79319e6ed752.png)
